### PR TITLE
Corrected spelling in docs for lux/chaos/gui/val

### DIFF
--- a/scribblings/lux.scrbl
+++ b/scribblings/lux.scrbl
@@ -183,7 +183,7 @@ height, and the third is the canvas's drawing context.}
 This module provides a helpful function for drawing functional images
 with @racketmodname[lux/chaos/gui].
 
-@defproc[(make-gui-val [#:scale? scale? boolean? #t])
+@defproc[(make-gui/val [#:scale? scale? boolean? #t])
          (-> pict-convertible?
              (-> real? real? (is-a?/c dc<%>) any))]{
 


### PR DESCRIPTION
The binding exported is make-gui/val, not make-gui-val