### PR TITLE
word: Export word generic methods.

### DIFF
--- a/word.rkt
+++ b/word.rkt
@@ -28,6 +28,24 @@
    (define (word-output w) #f)
    (define (word-return w) w)])
 
+(module+ generics
+  (provide
+   (contract-out
+    [word-fps
+     (-> word? flonum?)]
+    [word-label
+     (-> word? flonum? string?)]
+    [word-evt
+     (-> word? evt?)]
+    [word-event
+     (-> word? any/c word?)]
+    [word-tick
+     (-> word? word?)]
+    [word-output
+     (-> word? any/c)]
+    [word-return
+     (-> word? any/c)])))
+
 (define (default b f d) (if b (f b) d))
 (struct *word (fps label evt event tick output return)
   #:methods gen:word

--- a/word.rkt
+++ b/word.rkt
@@ -28,24 +28,6 @@
    (define (word-output w) #f)
    (define (word-return w) w)])
 
-(module+ generics
-  (provide
-   (contract-out
-    [word-fps
-     (-> word? flonum?)]
-    [word-label
-     (-> word? flonum? string?)]
-    [word-evt
-     (-> word? evt?)]
-    [word-event
-     (-> word? any/c word?)]
-    [word-tick
-     (-> word? word?)]
-    [word-output
-     (-> word? any/c)]
-    [word-return
-     (-> word? any/c)])))
-
 (define (default b f d) (if b (f b) d))
 (struct *word (fps label evt event tick output return)
   #:methods gen:word
@@ -193,6 +175,20 @@
  (contract-out
   [word?
    (-> any/c word?)]
+  [word-fps
+   (-> word? flonum?)]
+  [word-label
+   (-> word? flonum? string?)]
+  [word-evt
+   (-> word? evt?)]
+  [word-event
+   (-> word? any/c word?)]
+  [word-tick
+   (-> word? word?)]
+  [word-output
+   (-> word? any/c)]
+  [word-return
+   (-> word? any/c)]
   [word (->* () ((or/c #f word?)
                  #:fps real?
                  #:label (or/c string? (-> real? string?))


### PR DESCRIPTION
Here's why I'm doing this: I'm working on some meta-word usage.  A few uses:

 - Unit tests for words
 - Wrapping words in "debug words" that can capture inputs and states and roll forward and backward in time for a variety of games
 - words that contain words
 - etc etc